### PR TITLE
Bump kotlin.version from 2.0.20 to 2.0.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <maven.compiler.target>21</maven.compiler.target>
         <maven.compiler.source>21</maven.compiler.source>
-        <kotlin.version>2.0.20</kotlin.version>
+        <kotlin.version>2.0.21</kotlin.version>
         <jupiter.version>5.11.2</jupiter.version>
         <surefire.plugin.version>3.5.1</surefire.plugin.version>
         <maven.source.plugin.version>3.3.1</maven.source.plugin.version>


### PR DESCRIPTION
Bumps `kotlin.version` from 2.0.20 to 2.0.21.

Updates `org.jetbrains.kotlin:kotlin-stdlib` from 2.0.20 to 2.0.21
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/v2.0.21/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v2.0.20...v2.0.21)

Updates `org.jetbrains.kotlin:kotlin-compiler` from 2.0.20 to 2.0.21
- [Release notes](https://github.com/JetBrains/kotlin/releases)
- [Changelog](https://github.com/JetBrains/kotlin/blob/v2.0.21/ChangeLog.md)
- [Commits](https://github.com/JetBrains/kotlin/compare/v2.0.20...v2.0.21)

Updates `org.jetbrains.kotlin:kotlin-maven-plugin` from 2.0.20 to 2.0.21

---
updated-dependencies:
- dependency-name: org.jetbrains.kotlin:kotlin-stdlib dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.jetbrains.kotlin:kotlin-compiler dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.jetbrains.kotlin:kotlin-maven-plugin dependency-type: direct:production update-type: version-update:semver-patch ...